### PR TITLE
Added environment variable for allowing only specific URLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,5 +3,6 @@ Changelog
 
 0.2
 ----
+- Add environment variable for allowing only specific URLs [JeffersonBledsoe]
 - switched to using z3c.autoinclude to ensure security gets loaded after others
 - add utils helper to monkey patch methods that should only be used outside of restricted python

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/5-latest/versions.cfg
+extends = http://dist.plone.org/release/5.0-latest/versions.cfg
 extensions = mr.developer
 parts =
     instance

--- a/collective/trustedimports/plonelib.rst
+++ b/collective/trustedimports/plonelib.rst
@@ -32,7 +32,7 @@ or for a single object
 
 You can also add a CSRF token to URLs
 
->>> teval("from plone.protect.utils import addTokenToUrl"")
+>>> teval("from plone.protect.utils import addTokenToUrl")
 
 plone.app.textfield
 -------------------

--- a/collective/trustedimports/soap.rst
+++ b/collective/trustedimports/soap.rst
@@ -69,6 +69,46 @@ ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allow
 >>> del os.environ["SAFEIMPORTS_URL_BLACKLIST"]
 
 
+If we define a url allowlist environment variable, we can block all urls except for those in the allowlist
+
+>>> import os
+
+We should be able to open a url defined in the allowlist
+>>> os.environ["SAFEIMPORTS_URL_ALLOWLIST"] = "https://www.w3schools.com/Xml/tempconvert.asmx?WSDL"
+>>> teval("from zeep import Client;return Client('https://www.w3schools.com/Xml/tempconvert.asmx?WSDL')")
+<zeep.client.Client ...>
+
+But we should not have access to a URL not included on the allowlist
+>>> teval("from zeep import Client;return Client('https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl')")
+Traceback (most recent call last):
+...
+ValueError: URL https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl is not allowed to be accessed. URL is outside of allowlist
+
+>>> del os.environ["SAFEIMPORTS_URL_ALLOWLIST"]
+
+
+We should also be able to specify a wildcard to allow multile URLs from the same domain
+>>> os.environ["SAFEIMPORTS_URL_ALLOWLIST"] = "https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap*"
+>>> teval("from zeep import Client;return Client('https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl')")
+<zeep.client.Client ...>
+>>> teval("from zeep import Client;return Client('https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap_header.wsdl')")
+<zeep.client.Client ...>
+
+But we should not be able to access URLs from that domain which aren't included in the wildcard
+>>> teval("from zeep import Client;return Client('https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/http.wsdl')")
+Traceback (most recent call last):
+...
+ValueError: URL https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/http.wsdl is not allowed to be accessed. URL is outside of allowlist
+
+And we still shouldn't be able to access URLs outside of that domain
+>>> teval("from zeep import Client;return Client('https://www.w3schools.com/Xml/tempconvert.asmx?WSDL')")
+Traceback (most recent call last):
+...
+ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allowed to be accessed. URL is outside of allowlist
+
+>>> del os.environ["SAFEIMPORTS_URL_ALLOWLIST"]
+
+
 We can import exceptions too
 
 >>> teval("from zeep.exceptions import Error")

--- a/collective/trustedimports/soap.rst
+++ b/collective/trustedimports/soap.rst
@@ -109,6 +109,15 @@ ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allow
 >>> del os.environ["SAFEIMPORTS_URL_ALLOWLIST"]
 
 
+If both a blacklist and an allowlist are defined, URLs on the blacklist should take priority over URLs on the allowlist
+>>> os.environ["SAFEIMPORTS_URL_ALLOWLIST"] = "https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap*"
+>>> os.environ["SAFEIMPORTS_URL_BLACKLIST"] = "https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl"
+>>> teval("from zeep import Client;return Client('https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl')")
+Traceback (most recent call last):
+...
+ValueError: URL https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl is not allowed to be accessed. URL is in the blacklist
+
+
 We can import exceptions too
 
 >>> teval("from zeep.exceptions import Error")

--- a/collective/trustedimports/soap.rst
+++ b/collective/trustedimports/soap.rst
@@ -117,6 +117,9 @@ Traceback (most recent call last):
 ...
 ValueError: URL https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl is not allowed to be accessed. URL is in the blacklist
 
+>>> del os.environ["SAFEIMPORTS_URL_ALLOWLIST"]
+>>> del os.environ["SAFEIMPORTS_URL_BLACKLIST"]
+
 
 We can import exceptions too
 

--- a/collective/trustedimports/soap.rst
+++ b/collective/trustedimports/soap.rst
@@ -33,7 +33,7 @@ URL Restrictions
 
 *WARNING: The urls referenced in a downloaded WSDL are not currently checked for safety.*
 
-If we use the url blacklist we can prevent certain urls being accessed
+If we define a url blacklist environment variable, we can allow all urls to be access except for those on the blacklist
 
 >>> import os
 >>> os.environ["SAFEIMPORTS_URL_BLACKLIST"] = "www.w3schools.com;/*.asmx"
@@ -52,6 +52,11 @@ We cann't open connection to URL wildcard in blacklist
 Traceback (most recent call last):
 ...
 ValueError: URL http://www.dneonline.com/calculator.asmx?WSDL is not allowed to be accessed
+
+However, we can open a connection to a URL not in the blacklist
+
+>>> teval("from zeep import Client;return Client('https://raw.githubusercontent.com/mvantellingen/python-zeep/master/tests/wsdl_files/soap.wsdl')")
+<zeep.client.Client ...>
 
 'create_service' has restricted urls
 

--- a/collective/trustedimports/soap.rst
+++ b/collective/trustedimports/soap.rst
@@ -44,14 +44,14 @@ We can't open connection to URL in blacklist
 >>> teval("from zeep import Client;return Client('https://www.w3schools.com/Xml/tempconvert.asmx?WSDL')")
 Traceback (most recent call last):
 ...
-ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allowed to be accessed
+ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allowed to be accessed. URL is in the blacklist
 
 We cann't open connection to URL wildcard in blacklist
 
 >>> teval("from zeep import Client;return Client('http://www.dneonline.com/calculator.asmx?WSDL')")
 Traceback (most recent call last):
 ...
-ValueError: URL http://www.dneonline.com/calculator.asmx?WSDL is not allowed to be accessed
+ValueError: URL http://www.dneonline.com/calculator.asmx?WSDL is not allowed to be accessed. URL is in the blacklist
 
 However, we can open a connection to a URL not in the blacklist
 
@@ -63,7 +63,7 @@ However, we can open a connection to a URL not in the blacklist
 >>> teval("from zeep import Client;client = Client('https://www.w3schools.com/Xml/tempconvert.asmx?WSDL');return client.create_service('{https://www.w3schools.com/xml/}TempConvertSoap', 'http://www.w3schools.com')")
 Traceback (most recent call last):
 ...
-ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allowed to be accessed
+ValueError: URL https://www.w3schools.com/Xml/tempconvert.asmx?WSDL is not allowed to be accessed. URL is in the blacklist
 
 
 >>> del os.environ["SAFEIMPORTS_URL_BLACKLIST"]

--- a/collective/trustedimports/util.py
+++ b/collective/trustedimports/util.py
@@ -46,13 +46,23 @@ def is_url_allowed(url=None, uri=None, link=None):
     blacklist = os.getenv('SAFEIMPORTS_URL_BLACKLIST', '')
     # Use semicolin delimiter for multiple url in blacklist
     blacklist = ["*%s*" % domain.strip() for domain in blacklist.split(';') if domain.strip()]
-    if not blacklist:
-        return True
     for pattern in blacklist:
         for url in urls:
             if url.startswith('file://') or fnmatch.fnmatch(url, pattern):
-    return True
                 raise ValueError("URL %s is not allowed to be accessed. URL is in the blacklist" % url)
+    
+    allowlist = os.getenv('SAFEIMPORTS_URL_ALLOWLIST', '')
+
+    if not allowlist:
+        return True
+
+    allowlist = ["*%s*" % domain.strip() for domain in allowlist.split(';') if domain.strip()]
+    for pattern in allowlist:
+        for url in urls:
+            if url.startswith('file://') or fnmatch.fnmatch(url, pattern):
+                return True
+
+    raise ValueError("URL %s is not allowed to be accessed. URL is outside of allowlist" % url)
 
 def wrap_protected(method, *is_alloweds):
     """

--- a/collective/trustedimports/util.py
+++ b/collective/trustedimports/util.py
@@ -41,17 +41,18 @@ def restricted_python_call():
 
 
 def is_url_allowed(url=None, uri=None, link=None):
+    urls = [name for name in [url,uri,link] if name is not None]
+
     blacklist = os.getenv('SAFEIMPORTS_URL_BLACKLIST', '')
     # Use semicolin delimiter for multiple url in blacklist
     blacklist = ["*%s*" % domain.strip() for domain in blacklist.split(';') if domain.strip()]
     if not blacklist:
         return True
-    urls = [name for name in [url,uri,link] if name is not None]
     for pattern in blacklist:
         for url in urls:
             if url.startswith('file://') or fnmatch.fnmatch(url, pattern):
-                raise ValueError("URL %s is not allowed to be accessed" % url)
     return True
+                raise ValueError("URL %s is not allowed to be accessed. URL is in the blacklist" % url)
 
 def wrap_protected(method, *is_alloweds):
     """


### PR DESCRIPTION
When the environment variable `SAFEIMPORTS_URL_ALLOWLIST` is set all URLs will be disallowed by default and only those defined on the allowlist will be allowed.

When both the blocklist environment variable `SAFEIMPORTS_URL_BLACKLIST` and the new allowlist environment variable are defined, the blocklist environment variable will have a higher priority than the allowlist, allowing for fine-grained control over allowed and disallowed URLs.

There should be some more documentation on the allowing and blocking of URLs, however this should be covered in a separate PR