### PR TITLE
Fix failing tests

### DIFF
--- a/collective/trustedimports/plonelib.rst
+++ b/collective/trustedimports/plonelib.rst
@@ -32,7 +32,7 @@ or for a single object
 
 You can also add a CSRF token to URLs
 
->>> teval("from plone.protect.utils import addTokenToUrl"")
+>>> teval("from plone.protect.utils import addTokenToUrl")
 
 plone.app.textfield
 -------------------

--- a/collective/trustedimports/plonelib.rst
+++ b/collective/trustedimports/plonelib.rst
@@ -2,6 +2,7 @@ Plonelib
 ========
 
 #TODO: these should be moved into Plone itself
+>>> import doctest
 
 
 plone.subrequest
@@ -28,11 +29,17 @@ It's possible to disable CSRF protection on a request
 
 or for a single object
 
->>> teval("from plone.protect.utils import safeWrite")
+>>> if IS_PLONE_5:
+...     teval("from plone.protect.utils import safeWrite")
+... else:
+...     doctest.SKIP = True
 
 You can also add a CSRF token to URLs
 
->>> teval("from plone.protect.utils import addTokenToUrl")
+>>> if IS_PLONE_5:
+...     teval("from plone.protect.utils import addTokenToUrl")
+... else:
+...     doctest.SKIP = True
 
 plone.app.textfield
 -------------------

--- a/collective/trustedimports/tests.py
+++ b/collective/trustedimports/tests.py
@@ -14,6 +14,7 @@ from zope.component import eventtesting
 from zope.component import provideAdapter
 from zope.component import testing
 from zope.interface import Interface
+from plone import api
 import doctest
 import unittest
 import collective.trustedimports
@@ -173,7 +174,7 @@ def test_suite():
                 optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
                 setUp=setUp,
                 tearDown=testing.tearDown,
-                globs=dict(teval=teval),
+                globs=dict(teval=teval, IS_PLONE_5=api.env.plone_version().startswith('5')),
             ),
         )
 


### PR DESCRIPTION
- Fixed a typo in some earlier code
- Some of the plonelib code such as `addTokenToUrl` is new to 5.x. I've wrapped the tests for importing these in a check for the plone version so the tests aren't failing in 4.3

Closes #18 