### PR TITLE
Add icalendar to list of allowed modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 - Added `email.encoders.encode_base64` and `email.encoders` to allowed imports [instification]
 - switched to using `z3c.autoinclude` to ensure security gets loaded after others [djay]
 - add utils helper to monkey patch methods that should only be used outside of restricted python [djay]
+- Added `icalendar` to list of allowed modules [jeffersonbledsoe]
 
 
 0.1 (unreleased)

--- a/collective/trustedimports/configure.zcml
+++ b/collective/trustedimports/configure.zcml
@@ -16,6 +16,7 @@
     <include zcml:condition="installed collective.taskqueue" package=".collective_taskqueue"  />
 
     <include zcml:condition="installed defusedxml" package=".defusedxml"  />
+    <include zcml:condition="installed icalendar" package=".libicalendar"  />
     <include zcml:condition="installed lxml" package=".lxml"  />
     <include zcml:condition="installed pystache" package=".pystache"  />
     <include zcml:condition="installed phonenumbers" package=".phonenumbers"  />

--- a/collective/trustedimports/libicalendar.py
+++ b/collective/trustedimports/libicalendar.py
@@ -1,0 +1,3 @@
+from collective.trustedimports.util import whitelist_module
+
+whitelist_module('icalendar')

--- a/collective/trustedimports/libicalendar.py
+++ b/collective/trustedimports/libicalendar.py
@@ -1,23 +1,5 @@
-from AccessControl import allow_class, ModuleSecurityInfo, ClassSecurityInfo
 from collective.trustedimports.util import whitelist_module
-from collective.trustedimports.util import wrap_protected
-from Products.PythonScripts.Utility import allow_module
 import icalendar
-
-# from icalendar import Calendar, Event
+from icalendar import Calendar, Event
 
 whitelist_module("icalendar", classes=["Calendar", "Event"])
-# ModuleSecurityInfo("icalendar").declarePublic("Calendar")
-# allow_module("icalendar")
-# allow_class(icalendar.Calendar)
-# allow_class(icalendar.Event)
-
-# wrap_protected(icalendar.Calendar.__setattr__)
-# wrap_protected(icalendar.Calendar._write_)
-# allow_class
-# ModuleSecurityInfo("icalendar").declarePublic("Calendar")
-# ModuleSecurityInfo("icalendar").declarePublic("Event")
-
-
-# allow_module("icalendar.Calendar")
-# allow_module("icalendar.Event")

--- a/collective/trustedimports/libicalendar.py
+++ b/collective/trustedimports/libicalendar.py
@@ -1,3 +1,23 @@
+from AccessControl import allow_class, ModuleSecurityInfo, ClassSecurityInfo
 from collective.trustedimports.util import whitelist_module
+from collective.trustedimports.util import wrap_protected
+from Products.PythonScripts.Utility import allow_module
+import icalendar
 
-whitelist_module('icalendar')
+# from icalendar import Calendar, Event
+
+whitelist_module("icalendar", classes=["Calendar", "Event"])
+# ModuleSecurityInfo("icalendar").declarePublic("Calendar")
+# allow_module("icalendar")
+# allow_class(icalendar.Calendar)
+# allow_class(icalendar.Event)
+
+# wrap_protected(icalendar.Calendar.__setattr__)
+# wrap_protected(icalendar.Calendar._write_)
+# allow_class
+# ModuleSecurityInfo("icalendar").declarePublic("Calendar")
+# ModuleSecurityInfo("icalendar").declarePublic("Event")
+
+
+# allow_module("icalendar.Calendar")
+# allow_module("icalendar.Event")

--- a/collective/trustedimports/libicalendar.py
+++ b/collective/trustedimports/libicalendar.py
@@ -1,5 +1,16 @@
 from collective.trustedimports.util import whitelist_module
-import icalendar
-from icalendar import Calendar, Event
 
-whitelist_module("icalendar", classes=["Calendar", "Event"])
+whitelist_module(
+    "icalendar",
+    classes=[
+        "Calendar",
+        "Event",
+        "Todo",
+        "Journal",
+        "FreeBusy",
+        "Timezone",
+        "TimezoneStandard",
+        "TimezoneDaylight",
+        "Alarm",
+    ],
+)

--- a/collective/trustedimports/libicalendar.rst
+++ b/collective/trustedimports/libicalendar.rst
@@ -1,0 +1,24 @@
+icalendar
+=========
+
+I can import icalendar and it's classes
+
+>>> import icalendar
+
+>>> from icalendar import Calendar, Event
+
+I can construct a new Calendar
+
+>>> cal = Calendar()
+>>> print(cal)
+VCALENDAR({})
+
+I can add properties to the calendar
+
+>>> cal['dtstart'] = '20050404T080000'
+>>> cal['summary'] = 'Python meeting about calendaring'
+
+I can convert the calendar to a string
+
+>>> cal.to_ical()
+'BEGIN:VCALENDAR\r\nDTSTART:20050404T080000\r\nSUMMARY:Python meeting about calendaring\r\nEND:VCALENDAR\r\n'

--- a/collective/trustedimports/libicalendar.rst
+++ b/collective/trustedimports/libicalendar.rst
@@ -3,22 +3,28 @@ icalendar
 
 I can import icalendar and it's classes
 
->>> import icalendar
+>>> teval("import icalendar")
 
->>> from icalendar import Calendar, Event
+>>> teval("from icalendar import Calendar, Event")
 
 I can construct a new Calendar
 
->>> cal = Calendar()
->>> print(cal)
+>>> teval("from icalendar import Calendar; return Calendar()")
 VCALENDAR({})
 
-I can add properties to the calendar
+I can add properties to the calendar by using the `add` function
 
->>> cal['dtstart'] = '20050404T080000'
->>> cal['summary'] = 'Python meeting about calendaring'
+>>> teval("from icalendar import Calendar; cal = Calendar(); cal.add('summary', 'Python meeting about calendaring'); cal.add('attendee', 'MAILTO:maxm@mxm.dk'); cal.add('attendee', 'MAILTO:test@example.com'); return cal")
+VCALENDAR({u'ATTENDEE': [vCalAddress('MAILTO:maxm@mxm.dk'), vCalAddress('MAILTO:test@example.com')], u'SUMMARY': vText('Python meeting about calendaring')})
 
-I can convert the calendar to a string
+But properties can't be added to the calendar by using the slice syntax (`[value] = new_value`)
 
->>> cal.to_ical()
-'BEGIN:VCALENDAR\r\nDTSTART:20050404T080000\r\nSUMMARY:Python meeting about calendaring\r\nEND:VCALENDAR\r\n'
+>>> teval("from icalendar import Calendar; cal = Calendar(); cal['summary'] = 'Python meeting about calendaring'; cal['attendee'] = ['MAILTO:maxm@mxm.dk','MAILTO:test@example.com']; return cal")
+Traceback (most recent call last):
+...
+TypeError: object does not support item or slice assignment
+
+I can generate an ical string from the icalendar object
+
+>>> teval("from icalendar import Calendar; cal = Calendar(); cal.add('summary', 'Python meeting about calendaring'); cal.add('attendee', 'MAILTO:maxm@mxm.dk'); cal.add('attendee', 'MAILTO:test@example.com'); return cal.to_ical()")
+'BEGIN:VCALENDAR\r\nATTENDEE:MAILTO:maxm@mxm.dk\r\nATTENDEE:MAILTO:test@example.com\r\nSUMMARY:Python meeting about calendaring\r\nEND:VCALENDAR\r\n'

--- a/collective/trustedimports/libicalendar.rst
+++ b/collective/trustedimports/libicalendar.rst
@@ -5,7 +5,7 @@ I can import icalendar and it's classes
 
 >>> teval("import icalendar")
 
->>> teval("from icalendar import Calendar, Event")
+>>> teval("from icalendar import Calendar, Event, Todo, Journal, FreeBusy, Timezone, TimezoneStandard, TimezoneDaylight, Alarm")
 
 I can construct a new Calendar
 


### PR DESCRIPTION
This PR adds `icalendar` to the allowed list of imports.

In order to set properties on a Calendar or event, the user must use the `add` syntax as the slice syntax (`[value] = new_value`) remains restricted so as to not allow settings arbitrary values.