### PR TITLE
Allow mimetype.guess_type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 0.2 (unreleased)
 ----------------
 - Added Plone URL normalisers to allowed imports [jeffersonbledsoe]
+- Added `mimetype.guess_type` to allowed imports [jeffersonbledsoe]
 - Fixed test suite [jeffersonbledsoe]
 - Added `plone.protect.utils.addTokenToUrl` to allowed imports [jeffersonbledsoe]
 - Added plone protection to allowed imports for disabling CSRF checking [djay]

--- a/collective/trustedimports/stdlib.py
+++ b/collective/trustedimports/stdlib.py
@@ -90,3 +90,6 @@ whitelist_module('time')
 
 # formatdate
 ModuleSecurityInfo('email.Utils').declarePublic('formatdate')
+
+# mimetypes
+ModuleSecurityInfo("mimetypes").declarePublic("guess_type")

--- a/collective/trustedimports/stdlib.rst
+++ b/collective/trustedimports/stdlib.rst
@@ -78,3 +78,19 @@ Traceback (most recent call last):
 ...
 Unauthorized: import of 'os' is unauthorized
 
+mimetypes
+----
+We can import the guess_type function
+>>> teval("from mimetypes import guess_type")
+
+But the other functions are not allowed
+
+>>> teval("from mimetypes import add_type")
+Traceback (most recent call last):
+...
+Unauthorized: You are not allowed to access 'add_type' in this context
+
+>>> teval("import mimetypes; mimetypes.add_type('application/wasm','.wasm')")
+Traceback (most recent call last):
+...
+Unauthorized: You are not allowed to access 'add_type' in this context


### PR DESCRIPTION
This PR adds `mimetype.guess_type` to the list of allowed imports