### PR TITLE
Added pytz and plone.app.event.base.default_timezone to list of allowed modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 - add utils helper to monkey patch methods that should only be used outside of restricted python [djay]
 - Added `icalendar` to list of allowed modules [jeffersonbledsoe]
 - Added `html2text` to list of allowed modules [jeffersonbledsoe]
+- Added `pytz` and `plone.app.event.base.default_timezone` to list of allowed modules #29 [jeffersonbledsoe]
 
 
 0.1 (unreleased)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -54,3 +54,6 @@ robotframework-ride = 1.3
 robotframework-selenium2library = 1.6.0
 robotsuite = 1.6.1
 selenium = 2.46.0
+
+pycodestyle = >=2.6.0
+

--- a/collective/trustedimports/libicalendar.py
+++ b/collective/trustedimports/libicalendar.py
@@ -1,5 +1,6 @@
 from collective.trustedimports.util import whitelist_module
 
+whitelist_module("pytz")
 whitelist_module(
     "icalendar",
     classes=[

--- a/collective/trustedimports/libicalendar.rst
+++ b/collective/trustedimports/libicalendar.rst
@@ -28,3 +28,56 @@ I can generate an ical string from the icalendar object
 
 >>> teval("from icalendar import Calendar; cal = Calendar(); cal.add('summary', 'Python meeting about calendaring'); cal.add('attendee', 'MAILTO:maxm@mxm.dk'); cal.add('attendee', 'MAILTO:test@example.com'); return cal.to_ical()")
 'BEGIN:VCALENDAR\r\nATTENDEE:MAILTO:maxm@mxm.dk\r\nATTENDEE:MAILTO:test@example.com\r\nSUMMARY:Python meeting about calendaring\r\nEND:VCALENDAR\r\n'
+
+pytz
+====
+
+I can use pytz for timezone functions. These examples all come from the pytz docs https://pypi.org/project/pytz/
+
+>>> from datetime import datetime, timedelta
+>>> from pytz import timezone
+>>> import pytz
+>>> utc = pytz.utc
+>>> utc.zone
+'UTC'
+
+>>> eastern = timezone('US/Eastern')
+>>> eastern.zone
+'US/Eastern'
+
+>>> amsterdam = timezone('Europe/Amsterdam')
+>>> fmt = '%Y-%m-%d %H:%M:%S %Z%z'
+>>> loc_dt = eastern.localize(datetime(2002, 10, 27, 6, 0, 0))
+>>> print(loc_dt.strftime(fmt))
+2002-10-27 06:00:00 EST-0500
+
+>>> ams_dt = loc_dt.astimezone(amsterdam)
+>>> ams_dt.strftime(fmt)
+'2002-10-27 12:00:00 CET+0100'
+
+>>> utc_dt = datetime(2002, 10, 27, 6, 0, 0, tzinfo=utc)
+>>> loc_dt = utc_dt.astimezone(eastern)
+>>> loc_dt.strftime(fmt)
+'2002-10-27 01:00:00 EST-0500'
+
+>>> before = loc_dt - timedelta(minutes=10)
+>>> before.strftime(fmt)
+'2002-10-27 00:50:00 EST-0500'
+>>> eastern.normalize(before).strftime(fmt)
+'2002-10-27 01:50:00 EDT-0400'
+>>> after = eastern.normalize(before + timedelta(minutes=20))
+>>> after.strftime(fmt)
+'2002-10-27 01:10:00 EST-0500'
+
+>>> utc_dt = utc.localize(datetime.utcfromtimestamp(1143408899))
+>>> utc_dt.strftime(fmt)
+'2006-03-26 21:34:59 UTC+0000'
+>>> au_tz = timezone('Australia/Sydney')
+>>> au_dt = utc_dt.astimezone(au_tz)
+>>> au_dt.strftime(fmt)
+'2006-03-27 08:34:59 AEDT+1100'
+>>> utc_dt2 = au_dt.astimezone(utc)
+>>> utc_dt2.strftime(fmt)
+'2006-03-26 21:34:59 UTC+0000'
+>>> utc_dt == utc_dt2
+True

--- a/collective/trustedimports/plonelib.py
+++ b/collective/trustedimports/plonelib.py
@@ -1,3 +1,4 @@
+from collective.trustedimports.util import whitelist_module
 from AccessControl import allow_class, ModuleSecurityInfo, ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
 from Products.PythonScripts.Utility import allow_module
@@ -63,3 +64,6 @@ from plone.i18n.normalizer import idnormalizer
 ModuleSecurityInfo('plone.i18n.normalizer.interfaces').declarePublic('IUserPreferredURLNormalizer')
 allow_class(UserPreferredURLNormalizer)
 allow_class(idnormalizer)
+
+# plone.app.event
+ModuleSecurityInfo('plone.app.event.base').declarePublic('default_timezone')

--- a/collective/trustedimports/plonelib.rst
+++ b/collective/trustedimports/plonelib.rst
@@ -67,3 +67,11 @@ Usecase: Access a blob files data from restricted python
 
 plone.namedfile.file.NamedBlobFile
 
+plone.app.event
+---------------
+
+I import default_timezone
+
+>>> from plone.app.event.base import default_timezone
+>>> default_timezone
+<function default_timezone at ...


### PR DESCRIPTION
This PR adds pytz and plone.app.event.base.default_timezone to the list of allowed modules for more control over timezones