### PR TITLE
Fix html2text not being correctly allowed

### DIFF
--- a/collective/trustedimports/configure.zcml
+++ b/collective/trustedimports/configure.zcml
@@ -23,4 +23,6 @@
     <include zcml:condition="installed zeep" package=".soap"  />
     <include package=".url"  />
 
+    <!-- External packages  -->
+    <include zcml:condition="installed html2text" package=".libhtml2text"  />
 </configure>

--- a/collective/trustedimports/html2text.py
+++ b/collective/trustedimports/html2text.py
@@ -1,3 +1,0 @@
-from Products.PythonScripts.Utility import allow_module
-
-allow_module("html2text")

--- a/collective/trustedimports/libhtml2text.py
+++ b/collective/trustedimports/libhtml2text.py
@@ -1,0 +1,3 @@
+from collective.trustedimports.util import whitelist_module
+
+whitelist_module("html2text")

--- a/collective/trustedimports/libhtml2text.rst
+++ b/collective/trustedimports/libhtml2text.rst
@@ -1,0 +1,18 @@
+icalendar
+=========
+
+I can import html2text, it's helper function and it's class
+
+>>> teval("import html2text")
+
+>>> teval("from html2text import html2text")
+
+>>> teval("from html2text import HTML2Text")
+
+I can use the html2text helper function
+
+#>>> import pdb; pdb.set_trace()
+
+>>> teval("""import html2text; return html2text.html2text("<p><strong>Zed's</strong> dead baby, <em>Zed's</em> dead.</p>")""")
+u"**Zed's** dead baby, _Zed's_ dead.\n\n"
+

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             'Plone',
             'plone.api',
             'collective.taskqueue',
+            'html2text',
         ],
     },
     entry_points="""


### PR DESCRIPTION
#28 Added the `html2text` library to the list of allowed modules. However, a number of things were missing from this PR, causing it to not work. This PR fixes the support for html2text.